### PR TITLE
Use `EqualityComparer<T>` instead of non-generic `object.Equals`

### DIFF
--- a/src/QuikGraph/Algorithms/Condensation/EdgeMergeCondensationGraphAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/Condensation/EdgeMergeCondensationGraphAlgorithm.cs
@@ -91,12 +91,12 @@ namespace QuikGraph.Algorithms.Condensation
             // Add condensed edges
             foreach (MergedEdge<TVertex, TEdge> inEdge in inEdges)
             {
-                if (inEdge.Source.Equals(vertex))
+                if (EqualityComparer<TVertex>.Default.Equals(inEdge.Source, vertex))
                     continue;
 
                 foreach (MergedEdge<TVertex, TEdge> outEdge in outEdges)
                 {
-                    if (outEdge.Target.Equals(vertex))
+                    if (EqualityComparer<TVertex>.Default.Equals(outEdge.Target, vertex))
                         continue;
 
                     var newEdge = MergedEdge<TVertex, TEdge>.Merge(inEdge, outEdge);

--- a/src/QuikGraph/Algorithms/ConnectedComponents/StronglyConnectedComponentAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/ConnectedComponents/StronglyConnectedComponentAlgorithm.cs
@@ -20,7 +20,7 @@ namespace QuikGraph.Algorithms.ConnectedComponents
 #if SUPPORTS_SERIALIZATION
     [Serializable]
 #endif
-    public sealed class StronglyConnectedComponentsAlgorithm<TVertex, TEdge> 
+    public sealed class StronglyConnectedComponentsAlgorithm<TVertex, TEdge>
         : AlgorithmBase<IVertexListGraph<TVertex, TEdge>>
         , IConnectedComponentAlgorithm<TVertex, TEdge, IVertexListGraph<TVertex, TEdge>>
         where TEdge : IEdge<TVertex>
@@ -233,7 +233,7 @@ namespace QuikGraph.Algorithms.ConnectedComponents
                     Roots[vertex] = MinDiscoverTime(Roots[vertex], Roots[target]);
             }
 
-            if (Roots[vertex].Equals(vertex))
+            if (EqualityComparer<TVertex>.Default.Equals(Roots[vertex], vertex))
             {
                 TVertex w;
                 do
@@ -245,7 +245,7 @@ namespace QuikGraph.Algorithms.ConnectedComponents
                     VerticesPerStep.Add(w);
                     ++Steps;
                 }
-                while (!w.Equals(vertex));
+                while (!EqualityComparer<TVertex>.Default.Equals(w, vertex));
 
                 ++ComponentCount;
             }

--- a/src/QuikGraph/Algorithms/EulerianTrailAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/EulerianTrailAlgorithm.cs
@@ -141,7 +141,7 @@ namespace QuikGraph.Algorithms
                 _temporaryCircuit.Add(edge);
 
                 // edge.Target should be equal to CurrentVertex.
-                if (edge.Target.Equals(_currentVertex))
+                if (EqualityComparer<TVertex>.Default.Equals(edge.Target, _currentVertex))
                     return true;
 
                 // Continue search
@@ -214,7 +214,7 @@ namespace QuikGraph.Algorithms
             for (i = 0; i < _circuit.Count; ++i)
             {
                 TEdge edge = _circuit[i];
-                if (edge.Source.Equals(_currentVertex))
+                if (EqualityComparer<TVertex>.Default.Equals(edge.Source, _currentVertex))
                     break;
                 newCircuit.Add(edge);
             }
@@ -225,7 +225,7 @@ namespace QuikGraph.Algorithms
                 TEdge edge = _temporaryCircuit[j];
                 newCircuit.Add(edge);
                 OnCircuitEdge(edge);
-                if (edge.Target.Equals(_currentVertex))
+                if (EqualityComparer<TVertex>.Default.Equals(edge.Target, _currentVertex))
                     break;
             }
             _temporaryCircuit.Clear();
@@ -282,7 +282,7 @@ namespace QuikGraph.Algorithms
             bool foundEdge = false;
             foreach (TEdge edge in VisitedGraph.OutEdges(v))
             {
-                if (edge.Target.Equals(u))
+                if (EqualityComparer<TVertex>.Default.Equals(edge.Target, u))
                 {
                     foundEdge = true;
                     break;
@@ -303,7 +303,7 @@ namespace QuikGraph.Algorithms
             foreach (TEdge edge in VisitedGraph.OutEdges(u))
             {
                 TVertex v = edge.Target;
-                if (!v.Equals(u) && oddVertices.Contains(v))
+                if (!EqualityComparer<TVertex>.Default.Equals(v, u) && oddVertices.Contains(v))
                 {
                     foundAdjacent = true;
                     // Check that v does not have an out-edge towards u
@@ -477,7 +477,7 @@ namespace QuikGraph.Algorithms
                 TEdge edge = _circuit[i];
                 if (_temporaryEdges.Contains(edge))
                     continue;
-                if (edge.Source.Equals(startingVertex))
+                if (EqualityComparer<TVertex>.Default.Equals(edge.Source, startingVertex))
                     break;
             }
 

--- a/src/QuikGraph/Algorithms/GraphPartition/KernighanLinAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/GraphPartition/KernighanLinAlgorithm.cs
@@ -33,7 +33,7 @@ namespace QuikGraph.Algorithms.GraphPartition
         /// <param name="visitedGraph">Graph to visit.</param>
         /// <param name="nbIterations">Number of iterations to perform.</param>
         public KernighanLinAlgorithm(
-            [NotNull] IUndirectedGraph<TVertex, TEdge> visitedGraph, 
+            [NotNull] IUndirectedGraph<TVertex, TEdge> visitedGraph,
             int nbIterations)
             : base(visitedGraph)
         {
@@ -208,7 +208,8 @@ namespace QuikGraph.Algorithms.GraphPartition
         {
             foreach (TEdge edge in VisitedGraph.AdjacentEdges(vertexFromA))
             {
-                if (edge.Target.Equals(vertexFromB) || edge.Source.Equals(vertexFromB))
+                if (EqualityComparer<TVertex>.Default.Equals(edge.Target, vertexFromB)
+                    || EqualityComparer<TVertex>.Default.Equals(edge.Source, vertexFromB))
                 {
                     foundEdge = edge;
                     return true;

--- a/src/QuikGraph/Algorithms/MaximumBipartiteMatchingAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/MaximumBipartiteMatchingAlgorithm.cs
@@ -133,10 +133,10 @@ namespace QuikGraph.Algorithms
                 {
                     if (Math.Abs(flow.ResidualCapacities[edge]) < float.Epsilon)
                     {
-                        if (edge.Source.Equals(augmentor.SuperSource) 
-                            || edge.Source.Equals(augmentor.SuperSink) 
-                            || edge.Target.Equals(augmentor.SuperSource) 
-                            || edge.Target.Equals(augmentor.SuperSink))
+                        if (EqualityComparer<TVertex>.Default.Equals(edge.Source, augmentor.SuperSource)
+                            || EqualityComparer<TVertex>.Default.Equals(edge.Source, augmentor.SuperSink)
+                            || EqualityComparer<TVertex>.Default.Equals(edge.Target, augmentor.SuperSource)
+                            || EqualityComparer<TVertex>.Default.Equals(edge.Target, augmentor.SuperSink))
                         {
                             // Skip all edges that connect to SuperSource or SuperSink
                             continue;

--- a/src/QuikGraph/Algorithms/MaximumFlow/EdmondsKarpMaximumFlowAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/MaximumFlow/EdmondsKarpMaximumFlowAlgorithm.cs
@@ -85,7 +85,7 @@ namespace QuikGraph.Algorithms.MaximumFlow
                 e = Predecessors[u];
                 delta = Math.Min(delta, ResidualCapacities[e]);
                 u = e.Source;
-            } while (!u.Equals(source));
+            } while (!System.Collections.Generic.EqualityComparer<TVertex>.Default.Equals(u, source));
 
             // Push delta units of flow along the augmenting path
             u = sink;
@@ -98,7 +98,7 @@ namespace QuikGraph.Algorithms.MaximumFlow
                     ResidualCapacities[ReversedEdges[e]] += delta;
                 }
                 u = e.Source;
-            } while (!u.Equals(source));
+            } while (!System.Collections.Generic.EqualityComparer<TVertex>.Default.Equals(u, source));
         }
 
         #region AlgorithmBase<TGraph>

--- a/src/QuikGraph/Algorithms/MaximumFlow/GraphBalancingAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/MaximumFlow/GraphBalancingAlgorithm.cs
@@ -366,10 +366,10 @@ namespace QuikGraph.Algorithms.MaximumFlow
 
             bool IsSourceOrSink(TVertex v)
             {
-                return v.Equals(BalancingSource)
-                       || v.Equals(BalancingSink)
-                       || v.Equals(Source)
-                       || v.Equals(Sink);
+                return EqualityComparer<TVertex>.Default.Equals(v, BalancingSource)
+                       || EqualityComparer<TVertex>.Default.Equals(v, BalancingSink)
+                       || EqualityComparer<TVertex>.Default.Equals(v, Source)
+                       || EqualityComparer<TVertex>.Default.Equals(v, Sink);
             }
 
             #endregion

--- a/src/QuikGraph/Algorithms/MaximumFlow/ReverseEdgeAugmentorAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/MaximumFlow/ReverseEdgeAugmentorAlgorithm.cs
@@ -88,7 +88,7 @@ namespace QuikGraph.Algorithms.MaximumFlow
 
             foreach (TEdge reversedEdge in VisitedGraph.OutEdges(edge.Target))
             {
-                if (reversedEdge.Target.Equals(edge.Source))
+                if (EqualityComparer<TVertex>.Default.Equals(reversedEdge.Target, edge.Source))
                 {
                     foundReversedEdge = reversedEdge;
                     return true;

--- a/src/QuikGraph/Algorithms/Observers/EdgePredecessorRecorderObserver.cs
+++ b/src/QuikGraph/Algorithms/Observers/EdgePredecessorRecorderObserver.cs
@@ -174,7 +174,7 @@ namespace QuikGraph.Algorithms.Observers
             Debug.Assert(edge != null);
             Debug.Assert(targetEdge != null);
 
-            if (!edge.Equals(targetEdge))
+            if (!EqualityComparer<TEdge>.Default.Equals(edge, targetEdge))
                 EdgesPredecessors[targetEdge] = edge;
         }
 
@@ -184,7 +184,7 @@ namespace QuikGraph.Algorithms.Observers
 
             foreach (TEdge edge in EdgesPredecessors.Values)
             {
-                if (finishedEdge.Equals(edge))
+                if (EqualityComparer<TEdge>.Default.Equals(finishedEdge, edge))
                     return;
             }
 

--- a/src/QuikGraph/Algorithms/Observers/VertexPredecessorPathRecorderObserver.cs
+++ b/src/QuikGraph/Algorithms/Observers/VertexPredecessorPathRecorderObserver.cs
@@ -99,7 +99,7 @@ namespace QuikGraph.Algorithms.Observers
 
             foreach (TEdge edge in VerticesPredecessors.Values)
             {
-                if (edge.Source.Equals(vertex))
+                if (EqualityComparer<TVertex>.Default.Equals(edge.Source, vertex))
                     return;
             }
 

--- a/src/QuikGraph/Algorithms/RandomGraphFactory.cs
+++ b/src/QuikGraph/Algorithms/RandomGraphFactory.cs
@@ -157,7 +157,7 @@ namespace QuikGraph.Algorithms
                 {
                     b = vertices[rng.Next(vertexCount)];
                 }
-                while (!selfEdges && a.Equals(b));
+                while (!selfEdges && EqualityComparer<TVertex>.Default.Equals(a, b));
 
                 if (graph.AddEdge(edgeFactory(a, b)))
                     ++j;
@@ -210,7 +210,7 @@ namespace QuikGraph.Algorithms
             [NotNull] Random rng,
             int vertexCount,
             int edgeCount,
-            bool selfEdges) 
+            bool selfEdges)
             where TEdge : IEdge<TVertex>
         {
             CreateInternal(graph, vertexFactory, edgeFactory, rng, vertexCount, edgeCount, selfEdges);

--- a/src/QuikGraph/Algorithms/RankedShortestPath/HoffmanPavleyRankedShortestPathAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/RankedShortestPath/HoffmanPavleyRankedShortestPathAlgorithm.cs
@@ -231,9 +231,9 @@ namespace QuikGraph.Algorithms.RankedShortestPath
                 new VertexDistanceRecorderObserver<TVertex, SReversedEdge<TVertex, TEdge>>(ReversedEdgeWeight);
             var shortestPath =
                 new DijkstraShortestPathAlgorithm<TVertex, SReversedEdge<TVertex, TEdge>>(
-                    this, 
-                    reversedGraph, 
-                    ReversedEdgeWeight, 
+                    this,
+                    reversedGraph,
+                    ReversedEdgeWeight,
                     DistanceRelaxer);
 
             using (successorsObserver.Attach(shortestPath))
@@ -294,7 +294,7 @@ namespace QuikGraph.Algorithms.RankedShortestPath
                 // Detection of loops
                 if (edgeIndex == 0)
                     pathVertices[edge.Source] = 0;
-                
+
                 // We should really allow only one key
                 if (pathVertices.ContainsKey(edge.Target))
                     break;
@@ -320,7 +320,7 @@ namespace QuikGraph.Algorithms.RankedShortestPath
             foreach (TEdge deviationEdge in VisitedGraph.OutEdges(previousVertex))
             {
                 // Skip self edges and equal edges
-                if (deviationEdge.Equals(edge) || deviationEdge.IsSelfEdge())
+                if (EqualityComparer<TEdge>.Default.Equals(deviationEdge, edge) || deviationEdge.IsSelfEdge())
                     continue;
 
                 // Any edge obviously creating a loop
@@ -360,7 +360,7 @@ namespace QuikGraph.Algorithms.RankedShortestPath
                 current = edge.Target;
             }
 
-            Debug.Assert(path.Count == 0 || path.ElementAt(path.Count - 1).Target.Equals(_target));
+            Debug.Assert(path.Count == 0 || EqualityComparer<TVertex>.Default.Equals(path.ElementAt(path.Count - 1).Target, _target));
         }
 
         [DebuggerDisplay("Weight = {" + nameof(Weight) + "}, Index = {" + nameof(DeviationIndex) + "}, Edge = {" + nameof(DeviationEdge) + "}")]

--- a/src/QuikGraph/Algorithms/RootedAlgorithmBase.cs
+++ b/src/QuikGraph/Algorithms/RootedAlgorithmBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 #if SUPPORTS_AGGRESSIVE_INLINING
 using System.Runtime.CompilerServices;
@@ -64,7 +65,7 @@ namespace QuikGraph.Algorithms
             if (root == null)
                 throw new ArgumentNullException(nameof(root));
 
-            bool changed = !_hasRootVertex || !Equals(_root, root);
+            bool changed = !_hasRootVertex || !EqualityComparer<TVertex>.Default.Equals(_root, root);
             _root = root;
             _hasRootVertex = true;
 

--- a/src/QuikGraph/Algorithms/RootedSearchAlgorithmBase.cs
+++ b/src/QuikGraph/Algorithms/RootedSearchAlgorithmBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using QuikGraph.Algorithms.Services;
@@ -58,7 +59,7 @@ namespace QuikGraph.Algorithms
             if (target == null)
                 throw new ArgumentNullException(nameof(target));
 
-            bool changed = !_hasTargetVertex || !Equals(_target, target);
+            bool changed = !_hasTargetVertex || !EqualityComparer<TVertex>.Default.Equals(_target, target);
             _target = target;
             _hasTargetVertex = true;
 

--- a/src/QuikGraph/Algorithms/Search/BestFirstFrontierSearchAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/Search/BestFirstFrontierSearchAlgorithm.cs
@@ -71,7 +71,7 @@ namespace QuikGraph.Algorithms.Search
                 throw new VertexNotFoundException("Target vertex is not part of the graph.");
 
             // Little shortcut
-            if (root.Equals(target))
+            if (EqualityComparer<TVertex>.Default.Equals(root, target))
             {
                 OnTargetReached();
                 return; // Found it
@@ -95,7 +95,7 @@ namespace QuikGraph.Algorithms.Search
                 TVertex n = entry.Value;
 
                 // (4) If node n is a target node, terminate with success
-                if (n.Equals(target))
+                if (EqualityComparer<TVertex>.Default.Equals(n, target))
                 {
                     OnTargetReached();
                     return;

--- a/src/QuikGraph/Algorithms/Search/UndirectedBreathFirstSearchAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/Search/UndirectedBreathFirstSearchAlgorithm.cs
@@ -135,7 +135,7 @@ namespace QuikGraph.Algorithms.Search
             Debug.Assert(edge != null);
 
             TreeEdge?.Invoke(
-                this, 
+                this,
                 new UndirectedEdgeEventArgs<TVertex, TEdge>(edge, reversed));
         }
 
@@ -163,7 +163,7 @@ namespace QuikGraph.Algorithms.Search
             Debug.Assert(edge != null);
 
             GrayTarget?.Invoke(
-                this, 
+                this,
                 new UndirectedEdgeEventArgs<TVertex, TEdge>(edge, reversed));
         }
 
@@ -282,7 +282,7 @@ namespace QuikGraph.Algorithms.Search
         {
             foreach (TEdge edge in VisitedGraph.AdjacentEdges(u))
             {
-                bool reversed = edge.Target.Equals(u);
+                bool reversed = EqualityComparer<TVertex>.Default.Equals(edge.Target, u);
                 TVertex v = reversed ? edge.Source : edge.Target;
                 OnExamineEdge(edge);
 

--- a/src/QuikGraph/Algorithms/Search/UndirectedDepthFirstSearchAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/Search/UndirectedDepthFirstSearchAlgorithm.cs
@@ -369,7 +369,7 @@ namespace QuikGraph.Algorithms.Search
                         continue; // Edge already visited
 
                     visitedEdges.Add(edge, 0);
-                    bool reversed = edge.Target.Equals(u);
+                    bool reversed = EqualityComparer<TVertex>.Default.Equals(edge.Target, u);
                     OnExamineEdge(edge, reversed);
                     TVertex v = reversed ? edge.Source : edge.Target;
                     GraphColor vColor = VerticesColors[v];

--- a/src/QuikGraph/Algorithms/ShortestPath/FloydWarshallAllShortestPathAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/ShortestPath/FloydWarshallAllShortestPathAlgorithm.cs
@@ -164,7 +164,7 @@ namespace QuikGraph.Algorithms.ShortestPath
             if (target == null)
                 throw new ArgumentNullException(nameof(target));
 
-            if (source.Equals(target))
+            if (EqualityComparer<TVertex>.Default.Equals(source, target))
             {
                 path = null;
                 return false;
@@ -189,7 +189,7 @@ namespace QuikGraph.Algorithms.ShortestPath
             {
                 SEquatableEdge<TVertex> current = todo.Pop();
 
-                Debug.Assert(!current.Source.Equals(current.Target));
+                Debug.Assert(!EqualityComparer<TVertex>.Default.Equals(current.Source, current.Target));
 
                 if (_data.TryGetValue(current, out VertexData data))
                 {

--- a/src/QuikGraph/Algorithms/ShortestPath/UndirectedShortestPathAlgorithmBase.cs
+++ b/src/QuikGraph/Algorithms/ShortestPath/UndirectedShortestPathAlgorithmBase.cs
@@ -159,9 +159,11 @@ namespace QuikGraph.Algorithms.ShortestPath
             Debug.Assert(source != null);
             Debug.Assert(target != null);
             Debug.Assert(
-                (edge.Source.Equals(source) && edge.Target.Equals(target))
+                (EqualityComparer<TVertex>.Default.Equals(edge.Source, source)
+                    && EqualityComparer<TVertex>.Default.Equals(edge.Target, target))
                 ||
-                (edge.Source.Equals(target) && edge.Target.Equals(source)));
+                (EqualityComparer<TVertex>.Default.Equals(edge.Source, target)
+                    && EqualityComparer<TVertex>.Default.Equals(edge.Target, source)));
 
             double du = Distances[source];
             double dv = Distances[target];

--- a/src/QuikGraph/Algorithms/ShortestPath/YenShortestPathsAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/ShortestPath/YenShortestPathsAlgorithm.cs
@@ -269,7 +269,7 @@ namespace QuikGraph.Algorithms.ShortestPath
                 foreach (EquatableTaggedEdge<TVertex, double> rootPathEdge in rootPath)
                 {
                     TVertex source = rootPathEdge.Source;
-                    if (!spurVertex.Equals(source))
+                    if (!EqualityComparer<TVertex>.Default.Equals(spurVertex, source))
                     {
                         verticesToRestore.Add(source);
 

--- a/src/QuikGraph/Algorithms/TSP/Task.cs
+++ b/src/QuikGraph/Algorithms/TSP/Task.cs
@@ -174,18 +174,18 @@ namespace QuikGraph.Algorithms.TSP
         [Pure]
         private double ComputeMaxCandidate(
             [NotNull, ItemNotNull] IEnumerable<TEdge> row,
-            [NotNull, ItemNotNull] IEnumerable<TEdge> column, 
+            [NotNull, ItemNotNull] IEnumerable<TEdge> column,
             [NotNull] TVertex source,
             [NotNull] TVertex target)
         {
             return
-                row.Where(edge => !edge.Target.Equals(target))
+                row.Where(edge => !EqualityComparer<TVertex>.Default.Equals(edge.Target, target))
                     .DefaultIfEmpty(null)
                     .Min(edge => edge is null
                         ? double.PositiveInfinity
                         : _weight[edge])
                 +
-                column.Where(edge => !edge.Source.Equals(source))
+                column.Where(edge => !EqualityComparer<TVertex>.Default.Equals(edge.Source, source))
                     .DefaultIfEmpty(null)
                     .Min(edge => edge is null
                         ? double.PositiveInfinity
@@ -239,7 +239,7 @@ namespace QuikGraph.Algorithms.TSP
             var weightsTake = new Dictionary<EquatableEdge<TVertex>, double>(_weight);
             var reverseEdge = new EquatableEdge<TVertex>(edgeForSplit.Target, edgeForSplit.Source);
             weightsTake.Remove(reverseEdge);
-            graphTake.RemoveEdgeIf(edge => edge.Equals(reverseEdge));
+            graphTake.RemoveEdgeIf(edge => reverseEdge.Equals(edge));
 
             foreach (TEdge outEdge in graphTake.OutEdges(v1))
             {

--- a/src/QuikGraph/Collections/BinaryHeap.cs
+++ b/src/QuikGraph/Collections/BinaryHeap.cs
@@ -242,7 +242,7 @@ namespace QuikGraph.Collections
         {
             for (int i = 0; i < Count; i++)
             {
-                if (Equals(value, _items[i].Value))
+                if (EqualityComparer<TValue>.Default.Equals(value, _items[i].Value))
                     return i;
             }
 

--- a/src/QuikGraph/Collections/ForestDisjointSet.cs
+++ b/src/QuikGraph/Collections/ForestDisjointSet.cs
@@ -101,7 +101,7 @@ namespace QuikGraph.Collections
             if (right == null)
                 throw new ArgumentNullException(nameof(right));
 
-            return FindSet(left).Equals(FindSet(right));
+            return EqualityComparer<T>.Default.Equals(FindSet(left), FindSet(right));
         }
 
         /// <inheritdoc />

--- a/src/QuikGraph/Extensions/AlgorithmExtensions.cs
+++ b/src/QuikGraph/Extensions/AlgorithmExtensions.cs
@@ -1060,7 +1060,7 @@ namespace QuikGraph.Algorithms
             [NotNull] ReversedEdgeAugmentorAlgorithm<TVertex, TEdge> reversedEdgeAugmentorAlgorithm)
             where TEdge : IEdge<TVertex>
         {
-            if (Equals(source, sink))
+            if (EqualityComparer<TVertex>.Default.Equals(source, sink))
                 throw new ArgumentException($"{nameof(source)} and {nameof(sink)} must be different.");
 
             // Compute maximum flow

--- a/src/QuikGraph/Extensions/EdgeExtensions.cs
+++ b/src/QuikGraph/Extensions/EdgeExtensions.cs
@@ -26,7 +26,7 @@ namespace QuikGraph
             if (edge is null)
                 throw new ArgumentNullException(nameof(edge));
 
-            return edge.Source.Equals(edge.Target);
+            return EqualityComparer<TVertex>.Default.Equals(edge.Source, edge.Target);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace QuikGraph
             if (vertex == null)
                 throw new ArgumentNullException(nameof(vertex));
 
-            return edge.Source.Equals(vertex) ? edge.Target : edge.Source;
+            return EqualityComparer<TVertex>.Default.Equals(edge.Source, vertex) ? edge.Target : edge.Source;
         }
 
         /// <summary>
@@ -64,7 +64,8 @@ namespace QuikGraph
             if (vertex == null)
                 throw new ArgumentNullException(nameof(vertex));
 
-            return edge.Source.Equals(vertex) || edge.Target.Equals(vertex);
+            return EqualityComparer<TVertex>.Default.Equals(edge.Source, vertex)
+                || EqualityComparer<TVertex>.Default.Equals(edge.Target, vertex);
         }
 
         /// <summary>
@@ -92,7 +93,7 @@ namespace QuikGraph
                 }
                 else
                 {
-                    if (!lastTarget.Equals(edge.Source))
+                    if (!EqualityComparer<TVertex>.Default.Equals(lastTarget, edge.Source))
                         return false;
                     lastTarget = edge.Target;
                 }
@@ -169,7 +170,7 @@ namespace QuikGraph
                 }
                 else
                 {
-                    if (!lastTarget.Equals(edge.Source))
+                    if (!EqualityComparer<TVertex>.Default.Equals(lastTarget, edge.Source))
                         return false;
                     if (vertices.ContainsKey(edge.Target))
                         return false;
@@ -220,15 +221,15 @@ namespace QuikGraph
                 throw new ArgumentNullException(nameof(vertex));
 
             TVertex currentVertex = vertex;
-            if (root.Equals(currentVertex))
+            if (EqualityComparer<TVertex>.Default.Equals(root, currentVertex))
                 return true;
 
             while (predecessors.TryGetValue(currentVertex, out TEdge predecessor))
             {
                 TVertex source = GetOtherVertex(predecessor, currentVertex);
-                if (currentVertex.Equals(source))
+                if (EqualityComparer<TVertex>.Default.Equals(currentVertex, source))
                     return false;
-                if (source.Equals(root))
+                if (EqualityComparer<TVertex>.Default.Equals(source, root))
                     return true;
                 currentVertex = source;
             }
@@ -336,8 +337,10 @@ namespace QuikGraph
             Debug.Assert(source != null);
             Debug.Assert(target != null);
 
-            return (edge.Source.Equals(source) && edge.Target.Equals(target))
-                   || (edge.Target.Equals(source) && edge.Source.Equals(target));
+            return (EqualityComparer<TVertex>.Default.Equals(edge.Source, source)
+                        && EqualityComparer<TVertex>.Default.Equals(edge.Target, target))
+                   || (EqualityComparer<TVertex>.Default.Equals(edge.Target, source)
+                        && EqualityComparer<TVertex>.Default.Equals(edge.Source, target));
         }
 
         /// <summary>
@@ -352,7 +355,7 @@ namespace QuikGraph
         /// <paramref name="target"/> match edge vertices, false otherwise.</returns>
         [Pure]
         public static bool SortedVertexEquality<TVertex>(
-            [NotNull] this IEdge<TVertex> edge, 
+            [NotNull] this IEdge<TVertex> edge,
             [NotNull] TVertex source,
             [NotNull] TVertex target)
         {
@@ -376,7 +379,8 @@ namespace QuikGraph
             Debug.Assert(source != null);
             Debug.Assert(target != null);
 
-            return edge.Source.Equals(source) && edge.Target.Equals(target);
+            return EqualityComparer<TVertex>.Default.Equals(edge.Source, source)
+                && EqualityComparer<TVertex>.Default.Equals(edge.Target, target);
         }
 
         /// <summary>

--- a/src/QuikGraph/Predicates/Graphs/FilteredVertexAndEdgeListGraph.cs
+++ b/src/QuikGraph/Predicates/Graphs/FilteredVertexAndEdgeListGraph.cs
@@ -52,7 +52,7 @@ namespace QuikGraph.Predicates
             if (edge == null)
                 throw new ArgumentNullException(nameof(edge));
 
-            return Edges.Any(e => Equals(edge, e));
+            return Edges.Any(e => EqualityComparer<TEdge>.Default.Equals(edge, e));
         }
 
         #endregion

--- a/src/QuikGraph/Structures/Edges/EquatableEdge.cs
+++ b/src/QuikGraph/Structures/Edges/EquatableEdge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 
@@ -29,7 +30,8 @@ namespace QuikGraph
         {
             if (other is null)
                 return false;
-            return Source.Equals(other.Source) && Target.Equals(other.Target);
+            return EqualityComparer<TVertex>.Default.Equals(Source, other.Source)
+                && EqualityComparer<TVertex>.Default.Equals(Target, other.Target);
         }
 
         /// <inheritdoc />

--- a/src/QuikGraph/Structures/Edges/EquatableTaggedEdge.cs
+++ b/src/QuikGraph/Structures/Edges/EquatableTaggedEdge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using QuikGraph.Constants;
@@ -50,7 +51,7 @@ namespace QuikGraph
             get => _tag;
             set
             {
-                if (Equals(_tag, value))
+                if (EqualityComparer<TTag>.Default.Equals(_tag, value))
                     return;
 
                 _tag = value;

--- a/src/QuikGraph/Structures/Edges/EquatableTermEdge.cs
+++ b/src/QuikGraph/Structures/Edges/EquatableTermEdge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 
@@ -43,8 +44,8 @@ namespace QuikGraph
         {
             if (other is null)
                 return false;
-            return Source.Equals(other.Source)
-                   && Target.Equals(other.Target)
+            return EqualityComparer<TVertex>.Default.Equals(Source, other.Source)
+                   && EqualityComparer<TVertex>.Default.Equals(Target, other.Target)
                    && SourceTerminal.Equals(other.SourceTerminal)
                    && TargetTerminal.Equals(other.TargetTerminal);
         }

--- a/src/QuikGraph/Structures/Edges/EquatableUndirectedEdge.cs
+++ b/src/QuikGraph/Structures/Edges/EquatableUndirectedEdge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 
@@ -12,7 +13,7 @@ namespace QuikGraph
     [Serializable]
 #endif
     [DebuggerDisplay("{" + nameof(Source) + "}<->{" + nameof(Target) + "}")]
-    public class EquatableUndirectedEdge<TVertex>: UndirectedEdge<TVertex>, IEquatable<EquatableUndirectedEdge<TVertex>>
+    public class EquatableUndirectedEdge<TVertex> : UndirectedEdge<TVertex>, IEquatable<EquatableUndirectedEdge<TVertex>>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EquatableUndirectedEdge{TVertex}"/> class.
@@ -29,7 +30,8 @@ namespace QuikGraph
         {
             if (other is null)
                 return false;
-            return Source.Equals(other.Source) && Target.Equals(other.Target);
+            return EqualityComparer<TVertex>.Default.Equals(Source, other.Source)
+                && EqualityComparer<TVertex>.Default.Equals(Target, other.Target);
         }
 
         /// <inheritdoc />

--- a/src/QuikGraph/Structures/Edges/SEquatableEdge.cs
+++ b/src/QuikGraph/Structures/Edges/SEquatableEdge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using JetBrains.Annotations;
@@ -52,8 +53,8 @@ namespace QuikGraph
             // ReSharper disable ConstantConditionalAccessQualifier
             // ReSharper disable ConstantNullCoalescingCondition
             // Justification: Because of struct default constructor
-            return Equals(Source, other.Source)
-                   && Equals(Target, other.Target);
+            return EqualityComparer<TVertex>.Default.Equals(Source, other.Source)
+                   && EqualityComparer<TVertex>.Default.Equals(Target, other.Target);
             // ReSharper restore ConstantNullCoalescingCondition
             // ReSharper restore ConstantConditionalAccessQualifier
         }

--- a/src/QuikGraph/Structures/Edges/SEquatableTaggedEdge.cs
+++ b/src/QuikGraph/Structures/Edges/SEquatableTaggedEdge.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using QuikGraph.Constants;
+using System.Collections.Generic;
 
 namespace QuikGraph
 {
@@ -65,7 +66,7 @@ namespace QuikGraph
             get => _tag;
             set
             {
-                if (Equals(_tag, value))
+                if (EqualityComparer<TTag>.Default.Equals(_tag, value))
                     return;
 
                 _tag = value;
@@ -86,8 +87,8 @@ namespace QuikGraph
             // ReSharper disable ConstantConditionalAccessQualifier
             // ReSharper disable ConstantNullCoalescingCondition
             // Justification: Because of struct default constructor
-            return Equals(Source, other.Source)
-                   && Equals(Target, other.Target);
+            return EqualityComparer<TVertex>.Default.Equals(Source, other.Source)
+                   && EqualityComparer<TVertex>.Default.Equals(Target, other.Target);
             // ReSharper restore ConstantNullCoalescingCondition
             // ReSharper restore ConstantConditionalAccessQualifier
         }

--- a/src/QuikGraph/Structures/Edges/SReversedEdge.cs
+++ b/src/QuikGraph/Structures/Edges/SReversedEdge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using JetBrains.Annotations;
@@ -52,7 +53,7 @@ namespace QuikGraph
         /// <inheritdoc />
         public bool Equals(SReversedEdge<TVertex, TEdge> other)
         {
-            return Equals(OriginalEdge, other.OriginalEdge);
+            return EqualityComparer<TEdge>.Default.Equals(OriginalEdge, other.OriginalEdge);
         }
 
         /// <inheritdoc />

--- a/src/QuikGraph/Structures/Edges/STaggedEdge.cs
+++ b/src/QuikGraph/Structures/Edges/STaggedEdge.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using QuikGraph.Constants;
+using System.Collections.Generic;
 
 namespace QuikGraph
 {
@@ -65,7 +66,7 @@ namespace QuikGraph
             get => _tag;
             set
             {
-                if (Equals(_tag, value))
+                if (EqualityComparer<TTag>.Default.Equals(_tag, value))
                     return;
 
                 _tag = value;

--- a/src/QuikGraph/Structures/Edges/STaggedUndirectedEdge.cs
+++ b/src/QuikGraph/Structures/Edges/STaggedUndirectedEdge.cs
@@ -69,7 +69,7 @@ namespace QuikGraph
             get => _tag;
             set
             {
-                if (Equals(_tag, value))
+                if (EqualityComparer<TTag>.Default.Equals(_tag, value))
                     return;
 
                 _tag = value;

--- a/src/QuikGraph/Structures/Edges/TaggedEdge.cs
+++ b/src/QuikGraph/Structures/Edges/TaggedEdge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using QuikGraph.Constants;
@@ -11,7 +12,7 @@ namespace QuikGraph
     /// <typeparam name="TVertex">Vertex type.</typeparam>
     /// <typeparam name="TTag">Tag type.</typeparam>
 #if SUPPORTS_SERIALIZATION
-	[Serializable]
+    [Serializable]
 #endif
     public class TaggedEdge<TVertex, TTag> : Edge<TVertex>, ITagged<TTag>
     {
@@ -49,7 +50,7 @@ namespace QuikGraph
             get => _tag;
             set
             {
-                if (Equals(_tag, value))
+                if (EqualityComparer<TTag>.Default.Equals(_tag, value))
                     return;
 
                 _tag = value;

--- a/src/QuikGraph/Structures/Edges/TaggedUndirectedEdge.cs
+++ b/src/QuikGraph/Structures/Edges/TaggedUndirectedEdge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using QuikGraph.Constants;
@@ -50,7 +51,7 @@ namespace QuikGraph
             get => _tag;
             set
             {
-                if (Equals(_tag, value))
+                if (EqualityComparer<TTag>.Default.Equals(_tag, value))
                     return;
 
                 _tag = value;

--- a/src/QuikGraph/Structures/Graphs/AdjacencyGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/AdjacencyGraph.cs
@@ -152,7 +152,7 @@ namespace QuikGraph
                 throw new ArgumentNullException(nameof(target));
 
             if (TryGetOutEdges(source, out IEnumerable<TEdge> outEdges))
-                return outEdges.Any(edge => edge.Target.Equals(target));
+                return outEdges.Any(edge => EqualityComparer<TVertex>.Default.Equals(edge.Target, target));
             return false;
         }
 
@@ -169,7 +169,7 @@ namespace QuikGraph
             {
                 foreach (TEdge e in edgeList)
                 {
-                    if (e.Target.Equals(target))
+                    if (EqualityComparer<TVertex>.Default.Equals(e.Target, target))
                     {
                         edge = e;
                         return true;
@@ -191,7 +191,7 @@ namespace QuikGraph
 
             if (_vertexEdges.TryGetValue(source, out IEdgeList<TVertex, TEdge> outEdges))
             {
-                edges = outEdges.Where(edge => edge.Target.Equals(target));
+                edges = outEdges.Where(edge => EqualityComparer<TVertex>.Default.Equals(edge.Target, target));
                 return true;
             }
 
@@ -331,13 +331,13 @@ namespace QuikGraph
             // Run over edges and remove each edge touching the vertex
             foreach (KeyValuePair<TVertex, IEdgeList<TVertex, TEdge>> pair in _vertexEdges)
             {
-                if (pair.Key.Equals(vertex))
+                if (EqualityComparer<TVertex>.Default.Equals(pair.Key, vertex))
                     continue; // We've already
 
                 // Collect edges to remove
                 foreach (TEdge edge in pair.Value.Clone())
                 {
-                    if (edge.Target.Equals(vertex))
+                    if (EqualityComparer<TVertex>.Default.Equals(edge.Target, vertex))
                     {
                         pair.Value.Remove(edge);
                         OnEdgeRemoved(edge);

--- a/src/QuikGraph/Structures/Graphs/ArrayAdjacencyGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/ArrayAdjacencyGraph.cs
@@ -98,7 +98,7 @@ namespace QuikGraph
                 throw new ArgumentNullException(nameof(edge));
 
             if (_vertexOutEdges.TryGetValue(edge.Source, out TEdge[] edges))
-                return edges.Any(e => e.Equals(edge));
+                return edges.Any(e => EqualityComparer<TEdge>.Default.Equals(e, edge));
             return false;
         }
 
@@ -183,7 +183,7 @@ namespace QuikGraph
             {
                 foreach (TEdge outEdge in outEdges)
                 {
-                    if (outEdge.Target.Equals(target))
+                    if (EqualityComparer<TVertex>.Default.Equals(outEdge.Target, target))
                     {
                         edge = outEdge;
                         return true;
@@ -205,7 +205,7 @@ namespace QuikGraph
 
             if (_vertexOutEdges.TryGetValue(source, out TEdge[] outEdges))
             {
-                edges = outEdges.Where(edge => edge.Target.Equals(target));
+                edges = outEdges.Where(edge => EqualityComparer<TVertex>.Default.Equals(edge.Target, target));
                 return true;
             }
 

--- a/src/QuikGraph/Structures/Graphs/ArrayBidirectionalGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/ArrayBidirectionalGraph.cs
@@ -120,7 +120,7 @@ namespace QuikGraph
 
             if (_vertexEdges.TryGetValue(edge.Source, out InOutEdges inOutEdges))
             {
-                return inOutEdges.OutEdges.Any(e => e.Equals(edge));
+                return inOutEdges.OutEdges.Any(e => EqualityComparer<TEdge>.Default.Equals(e, edge));
             }
 
             return false;
@@ -148,7 +148,7 @@ namespace QuikGraph
             {
                 foreach (TEdge outEdge in inOutEdges.OutEdges)
                 {
-                    if (outEdge.Target.Equals(target))
+                    if (EqualityComparer<TVertex>.Default.Equals(outEdge.Target, target))
                     {
                         edge = outEdge;
                         return true;
@@ -170,7 +170,7 @@ namespace QuikGraph
 
             if (_vertexEdges.TryGetValue(source, out InOutEdges inOutEdges))
             {
-                edges = inOutEdges.OutEdges.Where(edge => edge.Target.Equals(target));
+                edges = inOutEdges.OutEdges.Where(edge => EqualityComparer<TVertex>.Default.Equals(edge.Target, target));
                 return true;
             }
 

--- a/src/QuikGraph/Structures/Graphs/ArrayUndirectedGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/ArrayUndirectedGraph.cs
@@ -107,7 +107,7 @@ namespace QuikGraph
                 throw new ArgumentNullException(nameof(edge));
 
             if (_vertexEdges.TryGetValue(edge.Source, out TEdge[] edges))
-                return edges.Any(e => e.Equals(edge));
+                return edges.Any(e => EqualityComparer<TEdge>.Default.Equals(e, edge));
             return false;
         }
 

--- a/src/QuikGraph/Structures/Graphs/BidirectionalGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/BidirectionalGraph.cs
@@ -154,7 +154,7 @@ namespace QuikGraph
                 throw new ArgumentNullException(nameof(target));
 
             if (TryGetOutEdges(source, out IEnumerable<TEdge> outEdges))
-                return outEdges.Any(edge => edge.Target.Equals(target));
+                return outEdges.Any(edge => EqualityComparer<TVertex>.Default.Equals(edge.Target, target));
             return false;
         }
 
@@ -234,7 +234,7 @@ namespace QuikGraph
             {
                 foreach (TEdge e in outEdges)
                 {
-                    if (e.Target.Equals(target))
+                    if (EqualityComparer<TVertex>.Default.Equals(e.Target, target))
                     {
                         edge = e;
                         return true;
@@ -256,7 +256,7 @@ namespace QuikGraph
 
             if (_vertexOutEdges.TryGetValue(source, out IEdgeList<TVertex, TEdge> outEdges))
             {
-                edges = outEdges.Where(edge => edge.Target.Equals(target));
+                edges = outEdges.Where(edge => EqualityComparer<TVertex>.Default.Equals(edge.Target, target));
                 return true;
             }
 
@@ -748,7 +748,7 @@ namespace QuikGraph
             {
                 foreach (TEdge target in outEdges)
                 {
-                    if (vertex.Equals(target.Target))
+                    if (EqualityComparer<TVertex>.Default.Equals(vertex, target.Target))
                         continue;
 
                     // We add an new edge

--- a/src/QuikGraph/Structures/Graphs/CompressedSparseRowGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/CompressedSparseRowGraph.cs
@@ -175,7 +175,7 @@ namespace QuikGraph
             {
                 for (int i = range.Start; i < range.End; ++i)
                 {
-                    if (_outEdges[i].Equals(target))
+                    if (EqualityComparer<TVertex>.Default.Equals(_outEdges[i], target))
                         return true;
                 }
             }
@@ -219,7 +219,7 @@ namespace QuikGraph
             {
                 for (int i = range.Start; i < range.End; ++i)
                 {
-                    if (_outEdges[i].Equals(target))
+                    if (EqualityComparer<TVertex>.Default.Equals(_outEdges[i], target))
                         yield return new SEquatableEdge<TVertex>(source, target);
                 }
             }

--- a/src/QuikGraph/Structures/Graphs/DelegateIncidenceGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/DelegateIncidenceGraph.cs
@@ -56,7 +56,7 @@ namespace QuikGraph
             {
                 foreach (TEdge outEdge in outEdges)
                 {
-                    if (outEdge.Target.Equals(target))
+                    if (EqualityComparer<TVertex>.Default.Equals(outEdge.Target, target))
                     {
                         edge = outEdge;
                         return true;
@@ -76,7 +76,7 @@ namespace QuikGraph
 
             if (TryGetOutEdges(source, out IEnumerable<TEdge> outEdges))
             {
-                edges = outEdges.Where(edge => edge.Target.Equals(target));
+                edges = outEdges.Where(edge => EqualityComparer<TVertex>.Default.Equals(edge.Target, target));
                 return true;
             }
 

--- a/src/QuikGraph/Structures/Graphs/DelegateUndirectedGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/DelegateUndirectedGraph.cs
@@ -72,7 +72,7 @@ namespace QuikGraph
         /// <inheritdoc />
         public virtual IEnumerable<TEdge> Edges =>
             _vertices.SelectMany(
-                vertex => AdjacentEdges(vertex).Where(edge => edge.Source.Equals(vertex)));
+                vertex => AdjacentEdges(vertex).Where(edge => EqualityComparer<TVertex>.Default.Equals(edge.Source, vertex)));
 
         /// <inheritdoc />
         public bool ContainsEdge(TEdge edge)
@@ -81,7 +81,7 @@ namespace QuikGraph
                 throw new ArgumentNullException(nameof(edge));
 
             if (TryGetAdjacentEdges(edge.Source, out IEnumerable<TEdge> edges))
-                return edges.Any(e => e.Equals(edge));
+                return edges.Any(e => EqualityComparer<TEdge>.Default.Equals(e, edge));
             return false;
         }
 
@@ -99,7 +99,7 @@ namespace QuikGraph
             if (vertex == null)
                 throw new ArgumentNullException(nameof(vertex));
 
-            return _vertices.Any(v => vertex.Equals(v));
+            return _vertices.Any(v => EqualityComparer<TVertex>.Default.Equals(vertex, v));
         }
 
         #endregion
@@ -109,7 +109,7 @@ namespace QuikGraph
         private bool FilterEdges([NotNull] TEdge edge, [NotNull] TVertex vertex)
         {
             return IsInGraph(edge, vertex)
-                   && (edge.Source.Equals(vertex) || edge.Target.Equals(vertex));
+                   && (EqualityComparer<TVertex>.Default.Equals(edge.Source, vertex) || EqualityComparer<TVertex>.Default.Equals(edge.Target, vertex));
         }
 
         /// <summary>

--- a/src/QuikGraph/Structures/Graphs/DelegateVertexAndEdgeListGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/DelegateVertexAndEdgeListGraph.cs
@@ -72,7 +72,7 @@ namespace QuikGraph
         /// <inheritdoc />
         public virtual IEnumerable<TEdge> Edges =>
             _vertices.SelectMany(
-                vertex => OutEdges(vertex).Where(edge => edge.Source.Equals(vertex)));
+                vertex => OutEdges(vertex).Where(edge => EqualityComparer<TVertex>.Default.Equals(edge.Source, vertex)));
 
         /// <inheritdoc />
         public bool ContainsEdge(TEdge edge)
@@ -81,7 +81,7 @@ namespace QuikGraph
                 throw new ArgumentNullException(nameof(edge));
 
             if (TryGetOutEdges(edge.Source, out IEnumerable<TEdge> edges))
-                return edges.Any(e => e.Equals(edge));
+                return edges.Any(e => EqualityComparer<TEdge>.Default.Equals(e, edge));
             return false;
         }
 
@@ -99,7 +99,7 @@ namespace QuikGraph
             if (vertex == null)
                 throw new ArgumentNullException(nameof(vertex));
 
-            return _vertices.Any(v => vertex.Equals(v));
+            return _vertices.Any(v => EqualityComparer<TVertex>.Default.Equals(vertex, v));
         }
 
         #endregion
@@ -108,7 +108,7 @@ namespace QuikGraph
 
         private bool FilterEdges([NotNull] TEdge edge, [NotNull] TVertex vertex)
         {
-            return IsInGraph(edge, vertex) && edge.Source.Equals(vertex);
+            return IsInGraph(edge, vertex) && EqualityComparer<TVertex>.Default.Equals(edge.Source, vertex);
         }
 
         /// <summary>

--- a/src/QuikGraph/Structures/Graphs/EdgeListGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/EdgeListGraph.cs
@@ -81,7 +81,7 @@ namespace QuikGraph
                 throw new ArgumentNullException(nameof(vertex));
 
             return Edges.Any(
-                edge => edge.Source.Equals(vertex) || edge.Target.Equals(vertex));
+                edge => EqualityComparer<TVertex>.Default.Equals(edge.Source, vertex) || EqualityComparer<TVertex>.Default.Equals(edge.Target, vertex));
         }
 
         #endregion
@@ -89,7 +89,7 @@ namespace QuikGraph
         #region IEdgeSet<TVertex,TEdge>
 
         [NotNull]
-        private readonly EdgeEdgeDictionary<TVertex, TEdge> _edges 
+        private readonly EdgeEdgeDictionary<TVertex, TEdge> _edges
             = new EdgeEdgeDictionary<TVertex, TEdge>();
 
         /// <inheritdoc />

--- a/src/QuikGraph/Structures/Graphs/UndirectedGraph.cs
+++ b/src/QuikGraph/Structures/Graphs/UndirectedGraph.cs
@@ -60,7 +60,7 @@ namespace QuikGraph
             EdgeEqualityComparer = edgeEqualityComparer ?? throw new ArgumentNullException(nameof(edgeEqualityComparer));
 
             _reorder = typeof(IUndirectedEdge<TVertex>).IsAssignableFrom(typeof(TEdge))
-                ? (ReorderVertices) ((TVertex source, TVertex target, out TVertex orderedSource, out TVertex orderedTarget) =>
+                ? (ReorderVertices)((TVertex source, TVertex target, out TVertex orderedSource, out TVertex orderedTarget) =>
                 {
                     if (Comparer<TVertex>.Default.Compare(source, target) > 0)
                     {
@@ -175,7 +175,7 @@ namespace QuikGraph
 
             foreach (TEdge adjacentEdge in adjacentEdges)
             {
-                if (adjacentEdge.Equals(edge))
+                if (EqualityComparer<TEdge>.Default.Equals(adjacentEdge, edge))
                     return true;
             }
 


### PR DESCRIPTION
## Description
Replace calls to `object.Equals(object)`/`Equals(object, object)` with `EqualityComparer<T>.Default.Equals(T, T)` to reduce boxing when `T` is a value type.

This fixes #5 

## Benchmark
I chose `EdgePredecessorRecorderObserver` and `SEquatableEdge` as a representative benchmark, because it replaces
```c#
OnEdgeDiscovered() 
  SEquatableEdge.Equals(object)
    Equals(SEquatableEdge<TVertex> other)
      TVertex.Equals(object)
        TVertex.Equals(TVertex)
      TVertex.Equals(object)
        TVertex.Equals(TVertex)
```

with approximately

```c#
OnEdgeDiscovered()
  Equals(SEquatableEdge<TVertex> other)
    TVertex.Equals(TVertex)
    TVertex.Equals(TVertex)
```

```c#
[SimpleJob(RuntimeMoniker.NetCoreApp31)]
[MemoryDiagnoser]
public class Tests
{
    private AdjacencyGraph<MyStruct, SEquatableEdge<MyStruct>> graph;

    [Params(10, 100, 1_000, 2_000)]
    public int N { get; set; }

    private readonly struct MyStruct : IEquatable<MyStruct>
    {
        public long Prop1 { get; }
        public long Prop2 { get; }
        public long Prop3 { get; }
        public long Prop4 { get; }

        public MyStruct(int i)
        {
            Prop1 = i;
            Prop2 = i;
            Prop3 = i;
            Prop4 = i;
        }

        public bool Equals(MyStruct other)
        {
            return Prop1 == other.Prop1
                && Prop2 == other.Prop2
                && Prop3 == other.Prop3
                && Prop4 == other.Prop4;
        }

        public override bool Equals(object obj) =>
            obj is MyStruct other && Equals(other);

        public override int GetHashCode() => (int)Prop1;
    }

    [GlobalSetup]
    public void GlobalSetup()
    {
        graph = new AdjacencyGraph<MyStruct, SEquatableEdge<MyStruct>>();
        graph.AddVerticesAndEdgeRange(
            Enumerable.Range(0, N)
                .Select(i => new SEquatableEdge<MyStruct>(new MyStruct(i), new MyStruct(i + 1))));
    }

    [Benchmark]
    public object SEquatableEdge()
    {
        var recorder = new EdgePredecessorRecorderObserver<MyStruct, SEquatableEdge<MyStruct>>();

        var dfs = new EdgeDepthFirstSearchAlgorithm<MyStruct, SEquatableEdge<MyStruct>>(graph);
        using (recorder.Attach(dfs))
        {
            dfs.Compute(new MyStruct(0));
        }

        return dfs;
    }
}
```

## Results for `MyStruct` (large struct)
### master
```
|         Method |    N |          Mean |        Error |        StdDev |       Gen 0 |    Gen 1 |    Gen 2 |    Allocated |
|--------------- |----- |--------------:|-------------:|--------------:|------------:|---------:|---------:|-------------:|
| SEquatableEdge |   10 |      12.16 us |     0.091 us |      0.085 us |      9.1400 |        - |        - |     28.03 KB |
| SEquatableEdge |  100 |     394.99 us |     3.344 us |      3.128 us |    344.7266 |        - |        - |   1057.35 KB |
| SEquatableEdge | 1000 |  50,605.98 us |   695.996 us |    616.982 us |  28500.0000 | 100.0000 | 100.0000 |  87930.17 KB |
| SEquatableEdge | 2000 | 284,436.92 us | 5,655.086 us | 10,759.389 us | 112500.0000 | 500.0000 |        - | 347822.91 KB |
```

### PR
```
|         Method |    N |          Mean |       Error |      StdDev |    Gen 0 |    Gen 1 |    Gen 2 |  Allocated |
|--------------- |----- |--------------:|------------:|------------:|---------:|---------:|---------:|-----------:|
| SEquatableEdge |   10 |      8.283 us |   0.0923 us |   0.0863 us |   3.4943 |        - |        - |   10.73 KB |
| SEquatableEdge |  100 |    157.940 us |   2.5098 us |   2.2249 us |  34.6680 |   0.2441 |        - |  107.01 KB |
| SEquatableEdge | 1000 |  9,640.616 us | 191.9573 us | 413.2084 us | 234.3750 | 156.2500 | 156.2500 | 1078.16 KB |
| SEquatableEdge | 2000 | 38,349.891 us | 675.9138 us | 632.2502 us | 461.5385 | 384.6154 | 384.6154 | 2245.41 KB |
```

### Relative gains, calculated as `PR/master`
```
|         Method |    N | Time | Allocated |
|--------------- |----- |-----:|----------:|
| SEquatableEdge |   10 | 0.61 |    0.3828 |
| SEquatableEdge |  100 | 0.38 |    0.1012 |
| SEquatableEdge | 1000 | 0.19 |    0.0123 |
| SEquatableEdge | 2000 | 0.14 |    0.0006 |
```

## Results for `int` (small struct)
### master
```
|         Method |    N |           Mean |         Error |        StdDev |      Gen 0 |    Gen 1 | Gen 2 |    Allocated |
|--------------- |----- |---------------:|--------------:|--------------:|-----------:|---------:|------:|-------------:|
| BeEquivalentTo |   10 |       8.064 us |     0.0833 us |     0.0779 us |     3.8910 |        - |     - |     11.92 KB |
| BeEquivalentTo |  100 |     219.393 us |     1.8957 us |     1.5830 us |   139.4043 |        - |     - |    427.51 KB |
| BeEquivalentTo | 1000 |  23,921.815 us |   461.3458 us |   566.5741 us | 11593.7500 | 125.0000 |     - |  35907.63 KB |
| BeEquivalentTo | 2000 | 123,744.200 us | 1,229.9758 us | 1,150.5201 us | 46200.0000 |        - |     - | 142148.96 KB |
```

### PR
```
|         Method |    N |          Mean |       Error |      StdDev |    Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|--------------- |----- |--------------:|------------:|------------:|---------:|--------:|--------:|----------:|
| BeEquivalentTo |   10 |      5.326 us |   0.0586 us |   0.0520 us |   1.3885 |       - |       - |   4.26 KB |
| BeEquivalentTo |  100 |     90.722 us |   0.9823 us |   0.9189 us |  10.6201 |       - |       - |  32.77 KB |
| BeEquivalentTo | 1000 |  5,170.236 us |  40.5568 us |  37.9369 us |  93.7500 | 23.4375 |       - | 317.99 KB |
| BeEquivalentTo | 2000 | 20,346.336 us | 164.5421 us | 137.4001 us | 156.2500 | 31.2500 | 31.2500 |  656.7 KB |
```

### Relative gains, calculated as `PR/master`
```
|         Method |    N | Time | Allocated |
|--------------- |----- |-----:|----------:|
| SEquatableEdge |   10 | 0.66 |    0.3574 |
| SEquatableEdge |  100 | 0.41 |    0.0767 |
| SEquatableEdge | 1000 | 0.22 |    0.0088 |
| SEquatableEdge | 2000 | 0.16 |    0.0046 |
```