### PR TITLE
Add support for xml serialization of undirected graphs

### DIFF
--- a/src/QuikGraph.Serialization/SerializationExtensions.cs
+++ b/src/QuikGraph.Serialization/SerializationExtensions.cs
@@ -325,7 +325,7 @@ namespace QuikGraph.Serialization
             [NotNull] string vertexElementName,
             [NotNull] string edgeElementName,
             [NotNull] string namespaceUri)
-            where TGraph : IVertexAndEdgeListGraph<TVertex, TEdge>
+            where TGraph : IEdgeListGraph<TVertex, TEdge>
             where TEdge : IEdge<TVertex>
         {
             SerializeToXml(
@@ -371,7 +371,7 @@ namespace QuikGraph.Serialization
             [CanBeNull, InstantHandle] Action<XmlWriter, TGraph> writeGraphAttributes,
             [CanBeNull, InstantHandle] Action<XmlWriter, TVertex> writeVertexAttributes,
             [CanBeNull, InstantHandle] Action<XmlWriter, TEdge> writeEdgeAttributes)
-            where TGraph : IVertexAndEdgeListGraph<TVertex, TEdge>
+            where TGraph : IEdgeListGraph<TVertex, TEdge>
             where TEdge : IEdge<TVertex>
         {
             if (graph == null)

--- a/tests/QuikGraph.Serialization.Tests/XmlSerializationTests.cs
+++ b/tests/QuikGraph.Serialization.Tests/XmlSerializationTests.cs
@@ -98,14 +98,13 @@ namespace QuikGraph.Serialization.Tests
             {
                 yield return new TestCaseData(new AdjacencyGraph<Person, TaggedEdge<Person, string>>());
                 yield return new TestCaseData(new BidirectionalGraph<Person, TaggedEdge<Person, string>>());
+                yield return new TestCaseData(new UndirectedGraph<Person, TaggedEdge<Person, string>>());
             }
         }
 
         [TestCaseSource(nameof(XmlSerializationGraphTestCases))]
         public void SerializeToXml<TGraph>([NotNull] TGraph graph)
-            where TGraph 
-            : IVertexAndEdgeListGraph<Person, TaggedEdge<Person, string>>
-            , IMutableVertexAndEdgeSet<Person, TaggedEdge<Person, string>>
+            where TGraph: IMutableVertexAndEdgeSet<Person, TaggedEdge<Person, string>>
         {
             var persons = new List<Person>();
             var jacob = new Person("Jacob", "Hochstetler")


### PR DESCRIPTION
### Description
Changes the graph constraint in `SerializeToXml` to allow serialization of undirected graphs.

Fixes #11 