### PR TITLE
Fix A* implementation: also calculate cost on tree edge

### DIFF
--- a/src/QuikGraph/Algorithms/ShortestPath/AStarShortestPathAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/ShortestPath/AStarShortestPathAlgorithm.cs
@@ -131,9 +131,17 @@ namespace QuikGraph.Algorithms.ShortestPath
 
             bool decreased = Relax(edge);
             if (decreased)
+            {
+                TVertex target = edge.Target;
+                double distance = Distances[target];
+
+                _costs[target] = DistanceRelaxer.Combine(distance, CostHeuristic(target));
                 OnTreeEdge(edge);
+            }
             else
+            {
                 OnEdgeNotRelaxed(edge);
+            }
         }
 
         private void OnGrayTarget([NotNull] TEdge edge)

--- a/tests/QuikGraph.Tests/Algorithms/ShortestPath/AStarShortestPathAlgorithmTests.cs
+++ b/tests/QuikGraph.Tests/Algorithms/ShortestPath/AStarShortestPathAlgorithmTests.cs
@@ -358,5 +358,41 @@ namespace QuikGraph.Tests.Algorithms.ShortestPath
                 v => 0.0);
             Assert.Throws<NegativeWeightException>(() => algorithm.Compute(1));
         }
+
+        [Test]
+        public void AStar_HeuristicCalls()
+        {
+            var lineGraph = new AdjacencyGraph<int, Edge<int>>();
+            lineGraph.AddVerticesAndEdgeRange(new[]
+            {
+                new Edge<int>(2, 3),
+                new Edge<int>(3, 4),
+                new Edge<int>(2, 1),
+                new Edge<int>(1, 0)
+            });
+
+            int root = 2;
+
+            var heuristicCalls = new List<int>();
+            var algorithm = new AStarShortestPathAlgorithm<int, Edge<int>>(
+                lineGraph,
+                e => 1.0,
+                v => 
+                {
+                    // Goal is 2, h(v) = v
+                    heuristicCalls.Add(v);
+                    return v;
+                });
+
+            algorithm.Compute(root);
+
+            // Heuristic function must be called at least 4 times
+            Assert.GreaterOrEqual(4, heuristicCalls.Count);
+
+            // 0 must be expanded before 4
+            Assert.Contains(0, heuristicCalls);
+            Assert.Contains(4, heuristicCalls);
+            Assert.Less(heuristicCalls.IndexOf(0), heuristicCalls.IndexOf(4));
+        }
     }
 }

--- a/tests/QuikGraph.Tests/Algorithms/ShortestPath/AStarShortestPathAlgorithmTests.cs
+++ b/tests/QuikGraph.Tests/Algorithms/ShortestPath/AStarShortestPathAlgorithmTests.cs
@@ -362,6 +362,66 @@ namespace QuikGraph.Tests.Algorithms.ShortestPath
         [Test]
         public void AStar_HeuristicCalls()
         {
+            var edge01 = new Edge<int>(0, 1);
+            var edge02 = new Edge<int>(0, 2);
+            var edge03 = new Edge<int>(0, 3);
+            var edge14 = new Edge<int>(1, 4);
+            var edge23 = new Edge<int>(2, 3);
+            var edge34 = new Edge<int>(3, 4);
+
+            var graph = new AdjacencyGraph<int, Edge<int>>();
+            graph.AddVerticesAndEdgeRange(new[]
+            {
+                edge01,
+                edge02,
+                edge03,
+                edge23,
+                edge14,
+                edge34
+            });
+
+            const int root = 0;
+
+            var colorUpdates = new HashSet<GraphColor>
+            {
+                GraphColor.White, GraphColor.Gray, GraphColor.Black
+            };
+
+            int heuristicCalls = 0;
+            AStarShortestPathAlgorithm<int, Edge<int>> algorithm = null;
+            Func<int, double> heuristic = v =>
+            {
+                // ReSharper disable once PossibleNullReferenceException
+                // ReSharper disable once AccessToModifiedClosure
+                colorUpdates.Remove(algorithm.GetVertexColor(v));
+                ++heuristicCalls;
+                return 10.0 / heuristicCalls;
+            };
+
+            algorithm = new AStarShortestPathAlgorithm<int, Edge<int>>(
+                graph,
+                e =>
+                {
+                    if (e == edge01)
+                        return 8.0;
+                    if (e == edge02)
+                        return 6.0;
+                    if (e == edge03)
+                        return 20.0;
+                    if (e == edge34)
+                        return 5.0;
+                    return 1.0;
+                },
+                heuristic);
+
+            algorithm.Compute(root);
+
+            CollectionAssert.IsEmpty(colorUpdates);
+        }
+
+        [Test]
+        public void AStar_HeuristicCallCount()
+        {
             var lineGraph = new AdjacencyGraph<int, Edge<int>>();
             lineGraph.AddVerticesAndEdgeRange(new[]
             {
@@ -371,7 +431,7 @@ namespace QuikGraph.Tests.Algorithms.ShortestPath
                 new Edge<int>(1, 0)
             });
 
-            int root = 2;
+            const int root = 2;
 
             var heuristicCalls = new List<int>();
             var algorithm = new AStarShortestPathAlgorithm<int, Edge<int>>(


### PR DESCRIPTION
The current A* implementation does not calculate cost on tree edge. This causes the algorithm to expand the vertices in the wrong order (not guided by the heuristic function).

I traced the problem way back to QuickGraph in CodePlex. I believe this is an inaccuracy when translating the idea from [BGL code](https://www.boost.org/doc/libs/1_73_0/boost/graph/astar_search.hpp), see the method `tree_edge()`.