### PR TITLE
Relax the input type for transitive closure/reduction algorithms.

### DIFF
--- a/src/QuikGraph/Algorithms/TransitiveClosureAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/TransitiveClosureAlgorithm.cs
@@ -9,7 +9,7 @@ namespace QuikGraph.Algorithms
     /// </summary>
     /// <typeparam name="TVertex">Vertex type.</typeparam>
     /// <typeparam name="TEdge">Edge type.</typeparam>
-    public class TransitiveClosureAlgorithm<TVertex, TEdge> : AlgorithmBase<BidirectionalGraph<TVertex, TEdge>>
+    public class TransitiveClosureAlgorithm<TVertex, TEdge> : AlgorithmBase<IEdgeListGraph<TVertex, TEdge>>
         where TEdge : IEdge<TVertex>
     {
         /// <summary>
@@ -20,7 +20,7 @@ namespace QuikGraph.Algorithms
         /// <exception cref="T:System.ArgumentNullException"><paramref name="visitedGraph"/> is <see langword="null"/>.</exception>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="edgeFactory"/> is <see langword="null"/>.</exception>
         public TransitiveClosureAlgorithm(
-            [NotNull] BidirectionalGraph<TVertex, TEdge> visitedGraph,
+            [NotNull] IEdgeListGraph<TVertex, TEdge> visitedGraph,
             [NotNull] Func<TVertex, TVertex, TEdge> edgeFactory)
             : base(visitedGraph)
         {

--- a/src/QuikGraph/Algorithms/TransitiveReductionAlgorithm.cs
+++ b/src/QuikGraph/Algorithms/TransitiveReductionAlgorithm.cs
@@ -8,7 +8,7 @@ namespace QuikGraph.Algorithms
     /// </summary>
     /// <typeparam name="TVertex">Vertex type.</typeparam>
     /// <typeparam name="TEdge">Edge type.</typeparam>
-    public class TransitiveReductionAlgorithm<TVertex, TEdge> : AlgorithmBase<BidirectionalGraph<TVertex, TEdge>>
+    public class TransitiveReductionAlgorithm<TVertex, TEdge> : AlgorithmBase<IEdgeListGraph<TVertex, TEdge>>
         where TEdge : IEdge<TVertex>
     {
         /// <summary>
@@ -17,7 +17,7 @@ namespace QuikGraph.Algorithms
         /// <param name="visitedGraph">Graph to visit.</param>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="visitedGraph"/> is <see langword="null"/>.</exception>
         public TransitiveReductionAlgorithm(
-            [NotNull] BidirectionalGraph<TVertex, TEdge> visitedGraph)
+            [NotNull] IEdgeListGraph<TVertex, TEdge> visitedGraph)
             : base(visitedGraph)
         {
             TransitiveReduction = new BidirectionalGraph<TVertex, TEdge>();

--- a/src/QuikGraph/Extensions/AlgorithmExtensions.cs
+++ b/src/QuikGraph/Extensions/AlgorithmExtensions.cs
@@ -1191,7 +1191,7 @@ namespace QuikGraph.Algorithms
         [Pure]
         [NotNull]
         public static BidirectionalGraph<TVertex, TEdge> ComputeTransitiveReduction<TVertex, TEdge>(
-            [NotNull] this BidirectionalGraph<TVertex, TEdge> graph)
+            [NotNull] this IEdgeListGraph<TVertex, TEdge> graph)
             where TEdge : IEdge<TVertex>
         {
             var algorithm = new TransitiveReductionAlgorithm<TVertex, TEdge>(graph);
@@ -1212,7 +1212,7 @@ namespace QuikGraph.Algorithms
         [Pure]
         [NotNull]
         public static BidirectionalGraph<TVertex, TEdge> ComputeTransitiveClosure<TVertex, TEdge>(
-            [NotNull] this BidirectionalGraph<TVertex, TEdge> graph,
+            [NotNull] this IEdgeListGraph<TVertex, TEdge> graph,
             [NotNull] Func<TVertex, TVertex, TEdge> edgeFactory)
             where TEdge : IEdge<TVertex>
         {

--- a/tests/QuikGraph.Tests/Algorithms/TransitiveClosureAlgorithmTests.cs
+++ b/tests/QuikGraph.Tests/Algorithms/TransitiveClosureAlgorithmTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NUnit.Framework;
 using QuikGraph.Algorithms;
 using static QuikGraph.Tests.Algorithms.AlgorithmTestHelpers;
@@ -15,7 +15,7 @@ namespace QuikGraph.Tests.Algorithms
         [Test]
         public void Constructor()
         {
-            var graph = new BidirectionalGraph<int, Edge<int>>();
+            var graph = new AdjacencyGraph<int, Edge<int>>();
             var algorithm = new TransitiveClosureAlgorithm<int, Edge<int>>(graph, (v1, v2) => new Edge<int>(v1, v2));
             AssertAlgorithmState(algorithm, graph);
             Assert.IsNotNull(algorithm.TransitiveClosure);
@@ -24,7 +24,7 @@ namespace QuikGraph.Tests.Algorithms
         [Test]
         public void Constructor_Throws()
         {
-            var graph = new BidirectionalGraph<int, Edge<int>>();
+            var graph = new AdjacencyGraph<int, Edge<int>>();
             // ReSharper disable ObjectCreationAsStatement
             // ReSharper disable AssignNullToNotNullAttribute
             Assert.Throws<ArgumentNullException>(
@@ -41,7 +41,7 @@ namespace QuikGraph.Tests.Algorithms
         public void TransitiveClosure_ValueType()
         {
             // Test 1
-            var graph = new BidirectionalGraph<int, SEquatableEdge<int>>();
+            var graph = new AdjacencyGraph<int, SEquatableEdge<int>>();
             graph.AddVerticesAndEdgeRange(new[]
             {
                 new SEquatableEdge<int>(1, 2),
@@ -60,7 +60,7 @@ namespace QuikGraph.Tests.Algorithms
                 });
 
             // Test 2
-            graph = new BidirectionalGraph<int, SEquatableEdge<int>>();
+            graph = new AdjacencyGraph<int, SEquatableEdge<int>>();
             graph.AddVerticesAndEdgeRange(new[]
             {
                 new SEquatableEdge<int>(1, 2),
@@ -91,7 +91,7 @@ namespace QuikGraph.Tests.Algorithms
         public void TransitiveClosure_ReferenceType()
         {
             // Test 1
-            var graph = new BidirectionalGraph<int, EquatableEdge<int>>();
+            var graph = new AdjacencyGraph<int, EquatableEdge<int>>();
             graph.AddVerticesAndEdgeRange(new[]
             {
                 new EquatableEdge<int>(1, 2),
@@ -110,7 +110,7 @@ namespace QuikGraph.Tests.Algorithms
                 });
 
             // Test 2
-            graph = new BidirectionalGraph<int, EquatableEdge<int>>();
+            graph = new AdjacencyGraph<int, EquatableEdge<int>>();
             graph.AddVerticesAndEdgeRange(new[]
             {
                 new EquatableEdge<int>(1, 2),
@@ -147,7 +147,7 @@ namespace QuikGraph.Tests.Algorithms
             var edge12 = new EquatableEdge<string>(vertex1, vertex2);
             var edge23 = new EquatableEdge<string>(vertex2, vertex3);
 
-            var graph = new BidirectionalGraph<string, EquatableEdge<string>>();
+            var graph = new AdjacencyGraph<string, EquatableEdge<string>>();
             graph.AddVertexRange(new[] { vertex1, vertex2, vertex3, vertex4 });
             graph.AddEdgeRange(new[] { edge12, edge23 });
 

--- a/tests/QuikGraph.Tests/Algorithms/TransitiveReductionAlgorithmTests.cs
+++ b/tests/QuikGraph.Tests/Algorithms/TransitiveReductionAlgorithmTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NUnit.Framework;
 using QuikGraph.Algorithms;
 using static QuikGraph.Tests.Algorithms.AlgorithmTestHelpers;
@@ -15,7 +15,7 @@ namespace QuikGraph.Tests.Algorithms
         [Test]
         public void Constructor()
         {
-            var graph = new BidirectionalGraph<int, Edge<int>>();
+            var graph = new AdjacencyGraph<int, Edge<int>>();
             var algorithm = new TransitiveReductionAlgorithm<int, Edge<int>>(graph);
             AssertAlgorithmState(algorithm, graph);
             Assert.IsNotNull(algorithm.TransitiveReduction);
@@ -42,7 +42,7 @@ namespace QuikGraph.Tests.Algorithms
             var edge34 = new SEdge<int>(3, 4);
             var edge35 = new SEdge<int>(3, 5);
             var edge45 = new SEdge<int>(4, 5);
-            var graph = new BidirectionalGraph<int, SEdge<int>>();
+            var graph = new AdjacencyGraph<int, SEdge<int>>();
             graph.AddVerticesAndEdgeRange(new[]
             {
                 edge12, edge13, edge14, edge15,
@@ -65,7 +65,7 @@ namespace QuikGraph.Tests.Algorithms
             var edge65 = new SEdge<int>(6, 5);
             var edge67 = new SEdge<int>(6, 7);
             var edge74 = new SEdge<int>(7, 4);
-            graph = new BidirectionalGraph<int, SEdge<int>>();
+            graph = new AdjacencyGraph<int, SEdge<int>>();
             graph.AddVerticesAndEdgeRange(new[]
             {
                 edge01, edge02, edge03, edge23,
@@ -92,7 +92,7 @@ namespace QuikGraph.Tests.Algorithms
             var edge34 = new Edge<int>(3, 4);
             var edge35 = new Edge<int>(3, 5);
             var edge45 = new Edge<int>(4, 5);
-            var graph = new BidirectionalGraph<int, Edge<int>>();
+            var graph = new AdjacencyGraph<int, Edge<int>>();
             graph.AddVerticesAndEdgeRange(new[]
             {
                 edge12, edge13, edge14, edge15,
@@ -114,7 +114,7 @@ namespace QuikGraph.Tests.Algorithms
             var edge65 = new Edge<int>(6, 5);
             var edge67 = new Edge<int>(6, 7);
             var edge74 = new Edge<int>(7, 4);
-            graph = new BidirectionalGraph<int, Edge<int>>();
+            graph = new AdjacencyGraph<int, Edge<int>>();
             graph.AddVerticesAndEdgeRange(new[]
             {
                 edge01, edge02, edge03, edge23,
@@ -137,7 +137,7 @@ namespace QuikGraph.Tests.Algorithms
             const string vertex3 = "/test/notlinked";
             var edge12 = new Edge<string>(vertex1, vertex2);
 
-            var graph = new BidirectionalGraph<string, Edge<string>>();
+            var graph = new AdjacencyGraph<string, Edge<string>>();
             graph.AddVertexRange(new[] { vertex1, vertex2, vertex3 });
             graph.AddEdge(edge12);
 


### PR DESCRIPTION
Currently, the `TransitiveClosureAlgorithm` and `TransitiveReductionAlgorithm` classes take a `BidirectionalGraph<TVertex, TEdge>` as input which is quite restrictive. Since they only rely on the `IVertexSet.Vertices` and `IEdgeSet.Edges` properties of the input graph, they could accept an `IEdgeListGraph<TVertex, TEdge>` instead.