### PR TITLE
Relax undirected edge constructor validation

### DIFF
--- a/src/QuikGraph/Structures/Edges/UndirectedEdge.cs
+++ b/src/QuikGraph/Structures/Edges/UndirectedEdge.cs
@@ -23,20 +23,28 @@ namespace QuikGraph
         /// <param name="target">The target vertex.</param>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="target"/> is <see langword="null"/>.</exception>
-        /// <exception cref="T:System.ArgumentException">
-        /// <paramref name="target"/> is not lower than <paramref name="source"/> when using <see cref="M:System.Collections.Generic.Comparer{T}.Default"/>.
-        /// </exception>
         public UndirectedEdge([NotNull] TVertex source, [NotNull] TVertex target)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
             if (target == null)
                 throw new ArgumentNullException(nameof(target));
-            if (Comparer<TVertex>.Default.Compare(source, target) > 0)
-                throw new ArgumentException($"{nameof(source)} must be lower than {nameof(target)} in {GetType().Name}.");
 
-            Source = source;
-            Target = target;
+            TVertex orderedSource;
+            TVertex orderedTarget;
+            if (Comparer<TVertex>.Default.Compare(source, target) > 0)
+            {
+                orderedSource = target;
+                orderedTarget = source;
+            }
+            else
+            {
+                orderedSource = source;
+                orderedTarget = target;
+            }
+
+            Source = orderedSource;
+            Target = orderedTarget;
         }
 
         /// <inheritdoc />

--- a/tests/QuikGraph.Tests/Structures/Edges/EquatableUndirectedEdgeTests.cs
+++ b/tests/QuikGraph.Tests/Structures/Edges/EquatableUndirectedEdgeTests.cs
@@ -21,6 +21,15 @@ namespace QuikGraph.Tests.Structures
             var v2 = new ComparableTestVertex("v2");
             CheckEdge(new EquatableUndirectedEdge<ComparableTestVertex>(v1, v2), v1, v2);
             CheckEdge(new EquatableUndirectedEdge<ComparableTestVertex>(v1, v1), v1, v1);
+
+            // Order correctly on creation
+            CheckEdge(new EquatableUndirectedEdge<int>(2, 1), 1, 2);
+
+            // Comparable
+            var comparableV1 = new ComparableTestVertex("v1");
+            var comparableV2 = new ComparableTestVertex("v2");
+            CheckEdge(new EquatableUndirectedEdge<ComparableTestVertex>(comparableV2, comparableV1), comparableV1,
+                comparableV2);
         }
 
         [Test]
@@ -28,21 +37,17 @@ namespace QuikGraph.Tests.Structures
         {
             // ReSharper disable ObjectCreationAsStatement
             // ReSharper disable AssignNullToNotNullAttribute
-            Assert.Throws<ArgumentNullException>(() => new EquatableUndirectedEdge<TestVertex>(null, new TestVertex("v1")));
-            Assert.Throws<ArgumentNullException>(() => new EquatableUndirectedEdge<TestVertex>(new TestVertex("v1"), null));
+            Assert.Throws<ArgumentNullException>(() =>
+                new EquatableUndirectedEdge<TestVertex>(null, new TestVertex("v1")));
+            Assert.Throws<ArgumentNullException>(() =>
+                new EquatableUndirectedEdge<TestVertex>(new TestVertex("v1"), null));
             Assert.Throws<ArgumentNullException>(() => new EquatableUndirectedEdge<TestVertex>(null, null));
             // ReSharper restore AssignNullToNotNullAttribute
-
-            Assert.Throws<ArgumentException>(() => new EquatableUndirectedEdge<int>(2, 1));
 
             // Not comparable
             var v1 = new TestVertex("v1");
             var v2 = new TestVertex("v2");
             Assert.Throws<ArgumentException>(() => new EquatableUndirectedEdge<TestVertex>(v1, v2));
-
-            var comparableV1 = new ComparableTestVertex("v1");
-            var comparableV2 = new ComparableTestVertex("v2");
-            Assert.Throws<ArgumentException>(() => new EquatableUndirectedEdge<ComparableTestVertex>(comparableV2, comparableV1));
             // ReSharper restore ObjectCreationAsStatement
         }
 

--- a/tests/QuikGraph.Tests/Structures/Edges/TaggedUndirectedEdgeTests.cs
+++ b/tests/QuikGraph.Tests/Structures/Edges/TaggedUndirectedEdgeTests.cs
@@ -25,6 +25,16 @@ namespace QuikGraph.Tests.Structures
             CheckTaggedEdge(new TaggedUndirectedEdge<ComparableTestVertex, TestObject>(v1, v2, null), v1, v2, (TestObject)null);
             CheckTaggedEdge(new TaggedUndirectedEdge<ComparableTestVertex, TestObject>(v1, v1, null), v1, v1, (TestObject)null);
             CheckTaggedEdge(new TaggedUndirectedEdge<ComparableTestVertex, TestObject>(v1, v2, tag), v1, v2, tag);
+
+            // Order correctly on creation
+            CheckTaggedEdge(new TaggedUndirectedEdge<int, TestObject>(2, 1, null), 1, 2, (TestObject)null);
+
+            // Comparable
+            var comparableV1 = new ComparableTestVertex("v1");
+            var comparableV2 = new ComparableTestVertex("v2");
+            CheckTaggedEdge(
+                new TaggedUndirectedEdge<ComparableTestVertex, TestObject>(comparableV2, comparableV1, null),
+                comparableV1, comparableV2, (TestObject)null);
         }
 
         [Test]
@@ -32,21 +42,19 @@ namespace QuikGraph.Tests.Structures
         {
             // ReSharper disable ObjectCreationAsStatement
             // ReSharper disable AssignNullToNotNullAttribute
-            Assert.Throws<ArgumentNullException>(() => new TaggedUndirectedEdge<TestVertex, TestObject>(null, new TestVertex("v1"), null));
-            Assert.Throws<ArgumentNullException>(() => new TaggedUndirectedEdge<TestVertex, TestObject>(new TestVertex("v1"), null, null));
-            Assert.Throws<ArgumentNullException>(() => new TaggedUndirectedEdge<TestVertex, TestObject>(null, null, null));
+            Assert.Throws<ArgumentNullException>(() =>
+                new TaggedUndirectedEdge<TestVertex, TestObject>(null, new TestVertex("v1"), null));
+            Assert.Throws<ArgumentNullException>(() =>
+                new TaggedUndirectedEdge<TestVertex, TestObject>(new TestVertex("v1"), null, null));
+            Assert.Throws<ArgumentNullException>(() =>
+                new TaggedUndirectedEdge<TestVertex, TestObject>(null, null, null));
             // ReSharper restore AssignNullToNotNullAttribute
-
-            Assert.Throws<ArgumentException>(() => new TaggedUndirectedEdge<int, TestObject>(2, 1, null));
 
             // Not comparable
             var v1 = new TestVertex("v1");
             var v2 = new TestVertex("v2");
             Assert.Throws<ArgumentException>(() => new TaggedUndirectedEdge<TestVertex, TestObject>(v1, v2, null));
 
-            var comparableV1 = new ComparableTestVertex("v1");
-            var comparableV2 = new ComparableTestVertex("v2");
-            Assert.Throws<ArgumentException>(() => new TaggedUndirectedEdge<ComparableTestVertex, TestObject>(comparableV2, comparableV1, null));
             // ReSharper restore ObjectCreationAsStatement
         }
 

--- a/tests/QuikGraph.Tests/Structures/Edges/UndirectedEdgeTests.cs
+++ b/tests/QuikGraph.Tests/Structures/Edges/UndirectedEdgeTests.cs
@@ -21,6 +21,14 @@ namespace QuikGraph.Tests.Structures
             var v2 = new ComparableTestVertex("v2");
             CheckEdge(new UndirectedEdge<ComparableTestVertex>(v1, v2), v1, v2);
             CheckEdge(new UndirectedEdge<ComparableTestVertex>(v1, v1), v1, v1);
+
+            // Order correctly on creation
+            CheckEdge(new UndirectedEdge<int>(2, 1), 1, 2);
+
+            // Comparable
+            var comparableV1 = new ComparableTestVertex("v1");
+            var comparableV2 = new ComparableTestVertex("v2");
+            CheckEdge(new UndirectedEdge<ComparableTestVertex>(comparableV2, comparableV1), comparableV1, comparableV2);
         }
 
         [Test]
@@ -33,16 +41,11 @@ namespace QuikGraph.Tests.Structures
             Assert.Throws<ArgumentNullException>(() => new UndirectedEdge<TestVertex>(null, null));
             // ReSharper restore AssignNullToNotNullAttribute
 
-            Assert.Throws<ArgumentException>(() => new UndirectedEdge<int>(2, 1));
 
             // Not comparable
             var v1 = new TestVertex("v1");
             var v2 = new TestVertex("v2");
             Assert.Throws<ArgumentException>(() => new UndirectedEdge<TestVertex>(v1, v2));
-
-            var comparableV1 = new ComparableTestVertex("v1");
-            var comparableV2 = new ComparableTestVertex("v2");
-            Assert.Throws<ArgumentException>(() => new UndirectedEdge<ComparableTestVertex>(comparableV2, comparableV1));
             // ReSharper restore ObjectCreationAsStatement
         }
 


### PR DESCRIPTION
Currently, the `UndirectedEdge<TVertex>` class throws an `ArgumentException` when the target is not lower than the source when comparing them, this doesn't really fit the definition of "Undirected", if we require this comparison to be true for certain algorithms we should rearrange on creation and allow creation with any ordering of vertices